### PR TITLE
remove tqdm

### DIFF
--- a/src/tiktok_api_helper/cli_data_acquisition.py
+++ b/src/tiktok_api_helper/cli_data_acquisition.py
@@ -366,7 +366,7 @@ def run(
     exclude_from_usernames: Optional[ExcludeUsernamesListType] = None,
 ) -> None:
     """
-    Executes it and stores the results from the TikTok API in a local SQLite database.
+    Queries TikTok API and stores the results in specified database.
     """
     utils.setup_logging(file_level=logging.INFO, rich_level=logging.WARN)
 


### PR DESCRIPTION
Our use of TQDM required a guess of how many API calls would be required, and this is impractical.