### PR TITLE
Revert "use attrs.converters.default_if_none instead of @_<member_name>.default decorator."

### DIFF
--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -267,12 +267,8 @@ class TikTokApiRequestClient:
         # Attrs removes underscores from field names but the static type checker doesn't know that
         alias="credentials",
     )
-    _access_token_fetcher_session: rq.Session = attrs.field(
-        converter=attrs.converters.default_if_none(rq.Session)
-    )
-    _api_request_session: rq.Session = attrs.field(
-        converter=attrs.converters.default_if_none(rq.Session)
-    )
+    _access_token_fetcher_session: rq.Session = attrs.field()
+    _api_request_session: rq.Session = attrs.field()
     _raw_responses_output_dir: Path | None = None
     _api_rate_limit_wait_strategy: ApiRateLimitWaitStrategy = attrs.field(
         default=ApiRateLimitWaitStrategy.WAIT_FOUR_HOURS,
@@ -331,6 +327,14 @@ class TikTokApiRequestClient:
         logging.debug("Access token response: %s", access_data)
 
         return access_data["access_token"]
+
+    @_access_token_fetcher_session.default  # type: ignore - Attrs overload
+    def _default_access_token_fetcher_session(self):
+        return rq.Session()
+
+    @_api_request_session.default  # type: ignore - Attrs overload
+    def _make_session(self):
+        return rq.Session()
 
     @property
     def num_api_requests_sent(self):


### PR DESCRIPTION
Reverts CybersecurityForDemocracy/tiktok-library#42

Syntax is wrong :face_palm: