### PR TITLE
Fix infinite loop in run_repeated

### DIFF
--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -825,6 +825,7 @@ class TikTokApiClient:
             except (ApiServerError, InvalidSearchIdError, InvalidCountOrCursorError) as e:
                 if self._config.raise_error_on_persistent_api_server_error:
                     raise e from None
+                break
 
             finally:
                 # TODO(macpd): test partial result yielding


### PR DESCRIPTION
run_repeated loops infinitely (without progressing) if fetch_all/fetch_and_store_all fail with ApiServerError, InvalidSearchIdError, or InvalidCountOrCursorError)