### PR TITLE
Fix formatting and remove newline escape char in exception message.

### DIFF
--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -575,8 +575,8 @@ class TikTokApiRequestClient:
 
         if response.status_code == 429:
             msg = (
-                f"Response indicates rate limit exceeded: {response!r}.\n"
-                "num_api_requests_sent: {self.num_api_requests_sent}"
+                f"Response indicates rate limit exceeded: {response!r}. num_api_requests_sent: "
+                "{self.num_api_requests_sent}"
             )
             raise ApiRateLimitError(msg)
 

--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -575,8 +575,8 @@ class TikTokApiRequestClient:
 
         if response.status_code == 429:
             msg = (
-                f"Response indicates rate limit exceeded: {response!r}. num_api_requests_sent: "
-                "{self.num_api_requests_sent}"
+                f"Response indicates rate limit exceeded: {response!r}. "
+                f"num_api_requests_sent: {self.num_api_requests_sent}"
             )
             raise ApiRateLimitError(msg)
 


### PR DESCRIPTION
message was moved from a log message into an exception message in https://github.com/CybersecurityForDemocracy/tiktok-library/pull/71 , but `f` prefix was not applied to all strings, and newline char was not removed