### PR TITLE
add --video-id and --max-days-per-query flags

### DIFF
--- a/src/tiktok_research_api_helper/cli/custom_argument_types.py
+++ b/src/tiktok_research_api_helper/cli/custom_argument_types.py
@@ -247,9 +247,12 @@ MaxDaysPerQueryType = Annotated[
     typer.Option(
         help=(
             "Threshold for number of days between start and end dates at which a single query will "
-            "be split into multiple queries. IE if this is set to 3 and the start and end date are "
-            "7 days apart the query will be split in 3 queries with start and end dates: (start, "
-            "start + 3), (start + 3, start + 6), (start + 6, start + 7)"
+            "be split into multiple queries. Often the API gets overloaded and returns 500 (which "
+            "still consumes request quota) if the query returns lots of videos and the date range "
+            "is large. So reducing this can reduce 500 responses (and request quota consumption "
+            "from those) for queries that match lots of videos. IE if this is set to 3 and the "
+            "start and end date are 7 days apart the query will be split in 3 queries with start "
+            "and end dates: (start, start + 3), (start + 3, start + 6), (start + 6, start + 7)"
         )
     ),
 ]

--- a/src/tiktok_research_api_helper/cli/custom_argument_types.py
+++ b/src/tiktok_research_api_helper/cli/custom_argument_types.py
@@ -183,7 +183,6 @@ ExcludeUsernamesListType = Annotated[
 
 VideoIdType = Annotated[int, typer.Option(help="ID of specific video to query for.")]
 
-
 CrawlTagType = Annotated[
     str,
     typer.Option(
@@ -239,6 +238,18 @@ CatchupFromStartDate = Annotated[
             "this date with the provided time window, and then crawl without delay (aside from "
             "waiting for API quota reset) run_repeated would operate as normal (ie crawl_lag days "
             "away from current date) date in the format %Y%m%d (e.g. 20210101)"
+        )
+    ),
+]
+
+MaxDaysPerQueryType = Annotated[
+    int,
+    typer.Option(
+        help=(
+            "Threshold for number of days between start and end dates at which a single query will "
+            "be split into multiple queries. IE if this is set to 3 and the start and end date are "
+            "7 days apart the query will be split in 3 queries with start and end dates: (start, "
+            "start + 3), (start + 3, start + 6), (start + 6, start + 7)"
         )
     ),
 ]

--- a/src/tiktok_research_api_helper/cli/custom_argument_types.py
+++ b/src/tiktok_research_api_helper/cli/custom_argument_types.py
@@ -181,6 +181,9 @@ ExcludeUsernamesListType = Annotated[
     ),
 ]
 
+VideoIdType = Annotated[int, typer.Option(help="ID of specific video to query for.")]
+
+
 CrawlTagType = Annotated[
     str,
     typer.Option(

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -492,7 +492,6 @@ def run(
             f"{_API_ALLOWED_MAX_DAYS_PER_QUERY}. This is a restriction of the tiktok research API."
         )
 
-
     logging.log(logging.INFO, f"Arguments: {locals()}")
 
     # Using an actual datetime object instead of a string would not allows to

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -66,8 +66,8 @@ from tiktok_research_api_helper.query import (
 
 APP = typer.Typer(rich_markup_mode="markdown")
 
-_DEFAULT_MAX_DAYS_PER_QUERY = 7
-_API_ALLOWED_MAX_DAYS_PER_QUERY = 30
+_MAX_DAYS_PER_QUERY_DEFAULT = 7
+_DAYS_PER_QUERY_MAX_API_ALLOWED = 30
 _DEFAULT_CREDENTIALS_FILE_PATH = Path("./secrets.yaml")
 
 
@@ -441,7 +441,7 @@ def run(
     db_url: DBUrlType | None = None,
     stop_after_one_request: StopAfterOneRequestFlag = False,
     max_api_requests: MaxApiRequests | None = None,
-    max_days_per_query: MaxDaysPerQueryType = _DEFAULT_MAX_DAYS_PER_QUERY,
+    max_days_per_query: MaxDaysPerQueryType = _MAX_DAYS_PER_QUERY_DEFAULT,
     crawl_tag: CrawlTagType | None = None,
     raw_responses_output_dir: RawResponsesOutputDir | None = None,
     query_file_json: JsonQueryFileType | None = None,
@@ -486,10 +486,10 @@ def run(
             "only one."
         )
 
-    if max_days_per_query > _API_ALLOWED_MAX_DAYS_PER_QUERY or max_days_per_query <= 0:
+    if max_days_per_query > _DAYS_PER_QUERY_MAX_API_ALLOWED or max_days_per_query <= 0:
         raise typer.BadParameter(
             "--max-days-per-query must be a positive integer less than or equal to "
-            f"{_API_ALLOWED_MAX_DAYS_PER_QUERY}. This is a restriction of the tiktok research API."
+            f"{_DAYS_PER_QUERY_MAX_API_ALLOWED}. This is a restriction of the tiktok research API."
         )
 
     logging.log(logging.INFO, f"Arguments: {locals()}")
@@ -546,7 +546,7 @@ def run(
         query = generate_video_id_query(video_id)
         # Since query for a specific video by ID should only return 1 video, we use the max allowed
         # date span for queries.
-        max_days_per_query = _API_ALLOWED_MAX_DAYS_PER_QUERY
+        max_days_per_query = _DAYS_PER_QUERY_MAX_API_ALLOWED
     else:
         validate_mutually_exclusive_flags(
             {

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -220,7 +220,8 @@ def print_query(
             "--exclude-all-usernames, --video-id]"
         )
     if video_id:
-        if any([
+        if any(
+            [
                 include_any_hashtags,
                 exclude_any_hashtags,
                 include_all_hashtags,
@@ -231,7 +232,8 @@ def print_query(
                 exclude_all_keywords,
                 only_from_usernames,
                 exclude_from_usernames,
-            ]):
+            ]
+        ):
             raise typer.BadParameter("--video_id is mutually exclusisive with other flags")
         query = generate_video_id_query(video_id)
     else:
@@ -513,7 +515,8 @@ def run(
 
         query = get_query_file_json(query_file_json)
     elif video_id:
-        if any([
+        if any(
+            [
                 include_any_hashtags,
                 exclude_any_hashtags,
                 include_all_hashtags,
@@ -524,7 +527,8 @@ def run(
                 exclude_all_keywords,
                 only_from_usernames,
                 exclude_from_usernames,
-            ]):
+            ]
+        ):
             raise typer.BadParameter("--video_id is mutually exclusisive with other flags")
         query = generate_video_id_query(video_id)
     else:

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -240,7 +240,9 @@ def print_query(
                 exclude_from_usernames,
             ]
         ):
-            raise typer.BadParameter("--video_id is mutually exclusisive with other flags")
+            raise typer.BadParameter(
+                "--video-id is mutually exclusisive with other query specification flags"
+            )
         query = generate_video_id_query(video_id)
     else:
         validate_mutually_exclusive_flags(

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -485,11 +485,12 @@ def run(
             "only one."
         )
 
-    if max_days_per_query > 30:
+    if max_days_per_query > 30 or max_days_per_query <= 0:
         raise typer.BadParameter(
-            "--max-days-per-query must be less than or equal to 30. This is a restriction of the "
-            "tiktok research API."
+            "--max-days-per-query must be a positive integer less than or equal to 30. This is a
+            restriction of the tiktok research API."
         )
+
 
     logging.log(logging.INFO, f"Arguments: {locals()}")
 

--- a/src/tiktok_research_api_helper/cli/main.py
+++ b/src/tiktok_research_api_helper/cli/main.py
@@ -67,6 +67,7 @@ from tiktok_research_api_helper.query import (
 APP = typer.Typer(rich_markup_mode="markdown")
 
 _DEFAULT_MAX_DAYS_PER_QUERY = 7
+_API_ALLOWED_MAX_DAYS_PER_QUERY = 30
 _DEFAULT_CREDENTIALS_FILE_PATH = Path("./secrets.yaml")
 
 
@@ -485,10 +486,10 @@ def run(
             "only one."
         )
 
-    if max_days_per_query > 30 or max_days_per_query <= 0:
+    if max_days_per_query > _API_ALLOWED_MAX_DAYS_PER_QUERY or max_days_per_query <= 0:
         raise typer.BadParameter(
-            "--max-days-per-query must be a positive integer less than or equal to 30. This is a
-            restriction of the tiktok research API."
+            "--max-days-per-query must be a positive integer less than or equal to "
+            f"{_API_ALLOWED_MAX_DAYS_PER_QUERY}. This is a restriction of the tiktok research API."
         )
 
 
@@ -544,6 +545,9 @@ def run(
         ):
             raise typer.BadParameter("--video_id is mutually exclusisive with other flags")
         query = generate_video_id_query(video_id)
+        # Since query for a specific video by ID should only return 1 video, we use the max allowed
+        # date span for queries.
+        max_days_per_query = _API_ALLOWED_MAX_DAYS_PER_QUERY
     else:
         validate_mutually_exclusive_flags(
             {

--- a/src/tiktok_research_api_helper/query.py
+++ b/src/tiktok_research_api_helper/query.py
@@ -160,6 +160,7 @@ class VideoQueryJSONEncoder(json.JSONEncoder):
             return o.as_dict()
         return super().default(o)
 
+
 def generate_video_id_query(video_id: int) -> VideoQuery:
     return VideoQuery(**{_QUERY_AND_ARG_NAME: Cond(Fields.video_id, str(video_id), Op.EQ)})
 

--- a/src/tiktok_research_api_helper/query.py
+++ b/src/tiktok_research_api_helper/query.py
@@ -160,6 +160,9 @@ class VideoQueryJSONEncoder(json.JSONEncoder):
             return o.as_dict()
         return super().default(o)
 
+def generate_video_id_query(video_id: int) -> VideoQuery:
+    return VideoQuery(**{_QUERY_AND_ARG_NAME: Cond(Fields.video_id, str(video_id), Op.EQ)})
+
 
 def get_normalized_hashtag_set(comma_separated_hashtags: str) -> set[str]:
     """Takes a string of comma separated hashtag names and returns a set of hashtag names all

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,6 +9,7 @@ from tiktok_research_api_helper.query import (
     VideoQuery,
     VideoQueryJSONEncoder,
     generate_query,
+    generate_video_id_query,
     get_normalized_hashtag_set,
     get_normalized_keyword_set,
     get_normalized_username_set,
@@ -322,6 +323,19 @@ def test_normalized_keyword_set(test_input, expected):
 )
 def test_normalized_username_set(test_input, expected):
     assert get_normalized_username_set(test_input) == expected
+
+def test_generate_query_video_id():
+    assert generate_video_id_query(1234567).as_dict() == {
+        "and": [
+            {
+                "field_name": "video_id",
+                "field_values": [
+                    "1234567",
+                ],
+                "operation": "EQ",
+            }
+        ]
+    }
 
 
 def test_generate_query_include_any_hashtags():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -324,6 +324,7 @@ def test_normalized_keyword_set(test_input, expected):
 def test_normalized_username_set(test_input, expected):
     assert get_normalized_username_set(test_input) == expected
 
+
 def test_generate_query_video_id():
     assert generate_video_id_query(1234567).as_dict() == {
         "and": [


### PR DESCRIPTION
- `--video-id` allows querying for a specific video by ID (you still have to provide the start and end dates for the query due to API requirement)
- `--max-days-per-query` allows specifying how many days between start and end dates before the query is broken into multiple queries.