### PR TITLE
Fix typo and type hint

### DIFF
--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -120,7 +120,7 @@ class TikTokUserInfoResponse(TikTokResponse):
 
 @attrs.define
 class TikTokCommentsResponse(TikTokResponse):
-    comments: Sequence[any]
+    comments: Sequence[Any]
 
 
 @attrs.define

--- a/src/tiktok_research_api_helper/cli/custom_argument_types.py
+++ b/src/tiktok_research_api_helper/cli/custom_argument_types.py
@@ -57,7 +57,7 @@ ApiCredentialsFileType = Annotated[
 ]
 
 RawResponsesOutputDir = Annotated[
-    Path,
+    Optional[Path],
     typer.Option(
         exists=True,
         file_okay=False,


### PR DESCRIPTION
- Fix "any" -> "Any
- Fix missing "Optional" for function paremeter