### PR TITLE
make usre docker compose down is executed even if tests fail in postgres integation test (otherwise ephemeral containers are not cleaned up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ extra-dependencies = [
 run = "pytest tests/ -vv"
 postgres-integration-test-docker-as-sudo = [
   "sudo docker compose --file=docker-compose-postgres-integration-test.yml build",
-  "sudo docker compose --file=docker-compose-postgres-integration-test.yml run postgres-integration-test",
+  "- sudo docker compose --file=docker-compose-postgres-integration-test.yml run postgres-integration-test",
   "sudo docker compose --file=docker-compose-postgres-integration-test.yml down --remove-orphans"
 ]
 


### PR DESCRIPTION
add dash before command to have hatch run subsequent commands regardless of exit status https://hatch.pypa.io/latest/config/environment/overview/#scripts