### PR TITLE
break cursor iteration if cursor is None

### DIFF
--- a/src/tiktok_research_api_helper/api_client.py
+++ b/src/tiktok_research_api_helper/api_client.py
@@ -975,6 +975,13 @@ class TikTokApiClient:
 
             has_more = response.data.get("has_more", False)
             cursor = response.data.get("cursor")
+            
+            if cursor is None:
+                logging.debug(
+                    "Stopping comments fetch for video ID %s because cursor is empty.", video_id
+                )
+                has_more = False
+                break
 
             if cursor > MAX_COMMENTS_CURSOR:
                 logging.debug(


### PR DESCRIPTION
To prevent the later check `cursor > MAX_COMMENTS_CURSOR` from failing if `cursor` is `None`, we now check for that and break the loop.